### PR TITLE
Build poseidon image from scratch and explicitly EXPOSE 9091 port

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -14,4 +14,8 @@
 
 FROM BASEIMAGE
 
-COPY poseidon /poseidon
+ADD poseidon /
+
+EXPOSE 9091
+
+ENTRYPOINT ["/poseidon", "--log_dir=/"]

--- a/image/Makefile
+++ b/image/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Build the fcp image.
+# Build the poseidon image.
 #
 # Usage:
 #   [ARCH=amd64] [REGISTRY="gcr.io/google-containers"] make (build|push) 
@@ -24,8 +24,7 @@ ARCH?=amd64
 POSEIDON_BIN?=_output/dockerized/bin/linux/$(ARCH)/poseidon
 VERSION?=1.0
 
-# TODO(@irfan) : do we need to rather build our own image from scratch
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.7
+BASEIMAGE=scratch
 TEMP_DIR:=$(shell mktemp -d -t poseidonXXXXXX)
 
 all: build


### PR DESCRIPTION
This PR:

* Use scratch as the base image instead of hyper-kube for the sake of reducing the docker image size(300MB -> 30MB).

* Explicitly EXPOSE 9091 port in Dockerfile to tell users that poseidon process is listening on 9091.

/assign @shivramsrivastava 