### PR TITLE
Increasing the default timeout to 60m for the E2E tests

### DIFF
--- a/test/e2e-poseidon-gce.sh
+++ b/test/e2e-poseidon-gce.sh
@@ -62,5 +62,5 @@ cd test/e2e
 sed -i "s/huaweiposeidon\/poseidon:latest/gcr.io\/$project\/poseidon-amd64:${BUILD_VERSION}/" $POSEIDON_MANIFEST_FILE_PATH
 
 #Run e2e test
-go test -v . -ginkgo.v -args -testNamespace=${TEST_NAMESPACE} -firmamentManifestPath=${FIRMAMENT_MANIFEST_FILE_PATH} -poseidonManifestPath=${POSEIDON_MANIFEST_FILE_PATH}
+go test -v . -timeout=60m -ginkgo.v -args -testNamespace=${TEST_NAMESPACE} -firmamentManifestPath=${FIRMAMENT_MANIFEST_FILE_PATH} -poseidonManifestPath=${POSEIDON_MANIFEST_FILE_PATH}
 


### PR DESCRIPTION
This will fix the E2E test case failure.
Because in the last test case we are waiting for 5minutes for the pod to be in pending state, after which the test passes, but due to default timeout of 10 minutes the tests exits.

/assign @m1093782566 