### PR TITLE
Fixing the flags Parse error message in logs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -126,6 +126,12 @@ func ReadFromCommandLineFlags() {
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()
+
+	// This is required to make flag package suppress the below error msg
+	// ERROR: logging before flag.Parse:
+	// please refer https://github.com/kubernetes/kubernetes/issues/17162
+	flag.CommandLine.Parse([]string{})
+
 	viper.BindPFlags(pflag.CommandLine)
 	glog.Info("ReadFromCommandLineFlags", config)
 }

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e/framework/ginkgowrapper:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
@@ -23,6 +24,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",


### PR DESCRIPTION
This fix addresses the below Parse error message in the log.

```
ERROR: logging before flag.Parse:
```


/assign @m1093782566 