### PR TITLE
when a e2e case finished, delete the correspond pods in time

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//test/e2e/framework/ginkgowrapper:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
@@ -24,6 +25,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/test/e2e/poseidon_integration.go
+++ b/test/e2e/poseidon_integration.go
@@ -282,14 +282,13 @@ var _ = Describe("Poseidon", func() {
 				Expect(job.Status.Active).To(Equal(parallelism))
 
 				By("Job was in Running state... Time to delete the Job now...")
-				err = f.WaitForJobDelete(job.Name)
+				err = f.WaitForJobDelete(job)
 				Expect(err).NotTo(HaveOccurred())
 				By("Check for Job deletion")
 				_, err = clientset.BatchV1().Jobs(ns).Get(name, metav1.GetOptions{})
 				if err != nil {
 					Expect(errors.IsNotFound(err)).To(Equal(true))
 				}
-				Expect("Success").To(Equal("Success"))
 			})
 		})
 	})


### PR DESCRIPTION
when a e2e case finished, delete the correspond pods in time.

Fixes: #100