### PR TITLE
Poseidon behave like default scheduler

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,6 +43,7 @@ type poseidonConfig struct {
 	HealthCheckAddress string  `json:"healthCheckAddress,omitempty"`
 	K8sBurst           int     `json:"k8sBurst,omitempty"`
 	K8sQPS             float32 `json:"k8sQPS,omitempty"`
+	DefaultBehaviour   bool    `json:"defaultBehaviour,omitempty"`
 }
 
 // GetSchedulerName returns the SchedulerName from config
@@ -148,6 +149,10 @@ func GetBurst() int {
 	return config.K8sBurst
 }
 
+func GetDefaultBehaviour() bool {
+	return config.DefaultBehaviour
+}
+
 // ReadFromCommandLineFlags reads command line flags and these will override poseidonConfig file flags.
 func ReadFromCommandLineFlags() {
 	pflag.StringVar(&config.SchedulerName, "schedulerName", "poseidon", "The scheduler name with which pods are labeled")
@@ -165,6 +170,7 @@ func ReadFromCommandLineFlags() {
 	pflag.StringVar(&config.HealthCheckAddress, "healthCheckAddress", "0.0.0.0:8989", "Address on which to check the health status of poseidon")
 	pflag.Float32Var(&config.K8sQPS, "k8sQPS", 1000, "k8s Client QPS to configure")
 	pflag.IntVar(&config.K8sBurst, "k8sBurst", 500, "k8s clinet burst rate to configure")
+	pflag.BoolVar(&config.DefaultBehaviour, "defaultBehaviour", false, "Enable default scheduler behaviour")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()


### PR DESCRIPTION
This PR is to make Poseidon behave like default scheduler.

Setting the flag ```--defaultBehaviour=true``` will make 'Poseidon' behave like default-scheduler.
By default it will be set to false.

**Note:**
This behaviour will not schedule any 'kube-system' pods and it will not process any updates, delete request from 'kube-system' pods.

**Scenario:**
First bring up the cluster using default-scheduler and then remove the default-scheduler before starting 'Poseidon' as default scheduler.

**Removing default-scheduler:**
In the master node, move the file ```kube-scheduler.manifest``` from ```/etc/kubernetes/manifests``` path.
Check if the kube-scheduler is not running, after the above step.

**Running Poseidon:**
As a standalone process it can run with the flag mentioned above.
But if you need to run 'Poseidon' as deployment, first bring up the cluster and then bring up the 'Poseidon' and 'Firmament' deployments and then remove the default scheduler.
This is once the 'Poseidon' and 'Firmament' is scheduled to run on  node by default-scheduler then remove the default-scheduler using the step mentioned above.
