### PR TITLE
Adding a flag to enable/disable success events from Poseidon

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,6 +44,7 @@ type poseidonConfig struct {
 	K8sBurst           int     `json:"k8sBurst,omitempty"`
 	K8sQPS             float32 `json:"k8sQPS,omitempty"`
 	DefaultBehaviour   bool    `json:"defaultBehaviour,omitempty"`
+	DisableEvents      bool    `json:"disableEvents,omitempty"`
 }
 
 // GetSchedulerName returns the SchedulerName from config
@@ -153,6 +154,10 @@ func GetDefaultBehaviour() bool {
 	return config.DefaultBehaviour
 }
 
+func GetDisableEvents() bool {
+	return config.DisableEvents
+}
+
 // ReadFromCommandLineFlags reads command line flags and these will override poseidonConfig file flags.
 func ReadFromCommandLineFlags() {
 	pflag.StringVar(&config.SchedulerName, "schedulerName", "poseidon", "The scheduler name with which pods are labeled")
@@ -171,6 +176,7 @@ func ReadFromCommandLineFlags() {
 	pflag.Float32Var(&config.K8sQPS, "k8sQPS", 1000, "k8s Client QPS to configure")
 	pflag.IntVar(&config.K8sBurst, "k8sBurst", 500, "k8s clinet burst rate to configure")
 	pflag.BoolVar(&config.DefaultBehaviour, "defaultBehaviour", false, "Enable default scheduler behaviour")
+	pflag.BoolVar(&config.DisableEvents, "disableEvents", false, "Disable/Enable events from Poseidon")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	pflag.Parse()

--- a/pkg/k8sclient/events.go
+++ b/pkg/k8sclient/events.go
@@ -18,6 +18,7 @@ package k8sclient
 
 import (
 	"github.com/golang/glog"
+	"github.com/kubernetes-sigs/poseidon/pkg/config"
 	"github.com/kubernetes-sigs/poseidon/pkg/firmament"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -90,7 +91,9 @@ func (posiedonEvents *PoseidonEvents) ProcessEvents(deltas *firmament.Scheduling
 	//process in success events and failure events in prallel
 	// Note we
 	go posiedonEvents.ProcessFailureEvents(deltas.GetUnscheduledTasks())
-	go poseidonEvents.ProcessSuccessEvents(deltas.GetDeltas())
+	if config.GetDisableEvents() == false {
+		go poseidonEvents.ProcessSuccessEvents(deltas.GetDeltas())
+	}
 }
 
 // ProcessFailureEvents The failed/unscheduled task events are sent only once


### PR DESCRIPTION
This PR provides a flag to disable the success events.
By setting the below flag one can disable the success events from being sent to the k8s.

```--disableEvents=true```

By success events we mean the happy case were a pod gets assigned to a node, if a pod cannot be assigned to a node an warning/failure event will be sent.

* Note: 
The failure/warning events can't be disabled with this flag, they will be sent to the k8s in any case.