### PR TITLE
Ephemeral test case failure fix

### DIFF
--- a/pkg/k8sclient/nodewatcher.go
+++ b/pkg/k8sclient/nodewatcher.go
@@ -110,13 +110,13 @@ func (nw *NodeWatcher) parseNode(node *v1.Node, phase NodePhase) *Node {
 	cpuCapQuantity := node.Status.Capacity[v1.ResourceCPU]
 	cpuAllocQuantity := node.Status.Allocatable[v1.ResourceCPU]
 	memCapQuantity := node.Status.Capacity[v1.ResourceMemory]
-	memCap, _ := memCapQuantity.AsInt64()
+	memCap := memCapQuantity.MilliValue()
 	memAllocQuantity := node.Status.Allocatable[v1.ResourceMemory]
-	memAlloc, _ := memAllocQuantity.AsInt64()
+	memAlloc := memAllocQuantity.MilliValue()
 	ephemeralCapQty := node.Status.Capacity[v1.ResourceEphemeralStorage]
-	ephemeralCap, _ := ephemeralCapQty.AsInt64()
+	ephemeralCap := ephemeralCapQty.MilliValue()
 	ephemeralAllocQty := node.Status.Allocatable[v1.ResourceEphemeralStorage]
-	ephemeralAlloc, _ := ephemeralAllocQty.AsInt64()
+	ephemeralAlloc := ephemeralAllocQty.MilliValue()
 
 	return &Node{
 		Hostname:         node.Name,
@@ -125,10 +125,10 @@ func (nw *NodeWatcher) parseNode(node *v1.Node, phase NodePhase) *Node {
 		IsOutOfDisk:      isOutOfDisk,
 		CPUCapacity:      cpuCapQuantity.MilliValue(),
 		CPUAllocatable:   cpuAllocQuantity.MilliValue(),
-		MemCapacityKb:    memCap / bytesToKb,
-		MemAllocatableKb: memAlloc / bytesToKb,
-		EphemeralCapKb:   ephemeralCap / bytesToKb,
-		EphemeralAllocKb: ephemeralAlloc / bytesToKb,
+		MemCapacityKb:    memCap,
+		MemAllocatableKb: memAlloc,
+		EphemeralCapKb:   ephemeralCap,
+		EphemeralAllocKb: ephemeralAlloc,
 		Labels:           node.Labels,
 		Annotations:      node.Annotations,
 		Taints:           nw.getTaints(node),
@@ -323,6 +323,16 @@ func (nw *NodeWatcher) createResourceTopologyForNode(node *Node) *firmament.Reso
 				RamCap:       uint64(node.MemCapacityKb),
 				CpuCores:     float32(node.CPUCapacity),
 				EphemeralCap: uint64(node.EphemeralCapKb),
+			},
+			AvailableResources: &firmament.ResourceVector{
+				RamCap:       uint64(node.MemAllocatableKb),
+				CpuCores:     float32(node.CPUAllocatable),
+				EphemeralCap: uint64(node.EphemeralAllocKb),
+			},
+			ReservedResources: &firmament.ResourceVector{
+				RamCap:       uint64(node.MemCapacityKb - node.MemAllocatableKb),
+				CpuCores:     float32(node.CPUCapacity - node.CPUAllocatable),
+				EphemeralCap: uint64(node.EphemeralCapKb - node.EphemeralAllocKb),
 			},
 		},
 	}

--- a/pkg/k8sclient/nodewatcher_test.go
+++ b/pkg/k8sclient/nodewatcher_test.go
@@ -64,6 +64,11 @@ func BuildFirmamentResourceDescriptor(
 				CpuCores: cpuCores,
 				RamCap:   ramCap,
 			},
+			AvailableResources: &firmament.ResourceVector{},
+			ReservedResources: &firmament.ResourceVector{
+				CpuCores: cpuCores,
+				RamCap:   ramCap,
+			},
 		},
 		Children: []*firmament.ResourceTopologyNodeDescriptor{
 			{
@@ -181,7 +186,7 @@ func TestNodeWatcher_parseNode(t *testing.T) {
 		expected *Node
 	}{
 		{
-			node: BuildNode("node0", "10", "10000000000", nil, []v1.NodeCondition{
+			node: BuildNode("node0", "10", "10000000", nil, []v1.NodeCondition{
 				{
 					Type:   v1.NodeOutOfDisk,
 					Status: v1.ConditionFalse,
@@ -195,7 +200,7 @@ func TestNodeWatcher_parseNode(t *testing.T) {
 				IsOutOfDisk:      false,
 				CPUCapacity:      10000,
 				CPUAllocatable:   0,
-				MemCapacityKb:    9765625,
+				MemCapacityKb:    10000000000,
 				MemAllocatableKb: 0,
 				Labels:           nil,
 				Annotations:      nil,
@@ -222,7 +227,7 @@ func TestNodeWatcher_enqueueNodeAddition(t *testing.T) {
 		expected *Node
 	}{
 		{
-			node: BuildNode("node0", "10", "10000000000", nil, []v1.NodeCondition{
+			node: BuildNode("node0", "10", "10000000", nil, []v1.NodeCondition{
 				{
 					Type:   v1.NodeOutOfDisk,
 					Status: v1.ConditionFalse,
@@ -236,14 +241,14 @@ func TestNodeWatcher_enqueueNodeAddition(t *testing.T) {
 				IsOutOfDisk:      false,
 				CPUCapacity:      10000,
 				CPUAllocatable:   0,
-				MemCapacityKb:    9765625,
+				MemCapacityKb:    10000000000,
 				MemAllocatableKb: 0,
 				Labels:           nil,
 				Annotations:      nil,
 			},
 		},
 		{
-			node: BuildNode("node1", "10", "10000000000", nil, []v1.NodeCondition{
+			node: BuildNode("node1", "10", "10000000", nil, []v1.NodeCondition{
 				{
 					Type:   v1.NodeOutOfDisk,
 					Status: v1.ConditionFalse,
@@ -257,7 +262,7 @@ func TestNodeWatcher_enqueueNodeAddition(t *testing.T) {
 				IsOutOfDisk:      false,
 				CPUCapacity:      10000,
 				CPUAllocatable:   0,
-				MemCapacityKb:    9765625,
+				MemCapacityKb:    10000000000,
 				MemAllocatableKb: 0,
 				Labels:           nil,
 				Annotations:      nil,

--- a/pkg/k8sclient/podwatcher.go
+++ b/pkg/k8sclient/podwatcher.go
@@ -148,10 +148,10 @@ func (pw *PodWatcher) getCPUMemEphemeralRequest(pod *v1.Pod) (int64, int64, int6
 		cpuReqQuantity := request[v1.ResourceCPU]
 		cpuReq += cpuReqQuantity.MilliValue()
 		memReqQuantity := request[v1.ResourceMemory]
-		memReqCont, _ := memReqQuantity.AsInt64()
+		memReqCont := memReqQuantity.MilliValue()
 		memReq += memReqCont
 		ephemeralReqQuantity := request[v1.ResourceEphemeralStorage]
-		ephemeralReqCont, _ := ephemeralReqQuantity.AsInt64()
+		ephemeralReqCont := ephemeralReqQuantity.MilliValue()
 		ephemeralReq += ephemeralReqCont
 	}
 	return cpuReq, memReq, ephemeralReq
@@ -267,8 +267,8 @@ func (pw *PodWatcher) parsePod(pod *v1.Pod) *Pod {
 		},
 		State:          podPhase,
 		CPURequest:     cpuReq,
-		MemRequestKb:   memReq / bytesToKb,
-		EphemeralReqKb: ephemeralReq / bytesToKb,
+		MemRequestKb:   memReq,
+		EphemeralReqKb: ephemeralReq,
 		Labels:         pod.Labels,
 		Annotations:    pod.Annotations,
 		NodeSelector:   pod.Spec.NodeSelector,

--- a/pkg/k8sclient/podwatcher_test.go
+++ b/pkg/k8sclient/podwatcher_test.go
@@ -229,7 +229,7 @@ func TestPodWatcher_enqueuePodAddition(t *testing.T) {
 					Namespace: "Poseidon-Namespace",
 				},
 				CPURequest:   2000,
-				MemRequestKb: 1,
+				MemRequestKb: 1024000,
 				OwnerRef:     fakeOwnerRef,
 				Affinity: &Affinity{
 					NodeAffinity: &NodeAffinity{
@@ -299,7 +299,7 @@ func TestPodWatcher_enqueuePodAddition(t *testing.T) {
 					Namespace: "Poseidon-Namespace",
 				},
 				CPURequest:   2000,
-				MemRequestKb: 1,
+				MemRequestKb: 1024000,
 				OwnerRef:     fakeOwnerRef,
 				Affinity: &Affinity{
 					NodeAffinity: &NodeAffinity{
@@ -369,7 +369,7 @@ func TestPodWatcher_enqueuePodAddition(t *testing.T) {
 					Namespace: "Poseidon-Namespace",
 				},
 				CPURequest:   2000,
-				MemRequestKb: 1,
+				MemRequestKb: 1024000,
 				OwnerRef:     fakeOwnerRef,
 				Affinity: &Affinity{
 					NodeAffinity: &NodeAffinity{
@@ -439,7 +439,7 @@ func TestPodWatcher_enqueuePodAddition(t *testing.T) {
 					Namespace: "Poseidon-Namespace",
 				},
 				CPURequest:   2000,
-				MemRequestKb: 1,
+				MemRequestKb: 1024000,
 				OwnerRef:     fakeOwnerRef,
 				Affinity: &Affinity{
 					NodeAffinity: &NodeAffinity{

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -332,7 +332,7 @@ func (f *Framework) createFirmamentDeployment() (*v1beta1.Deployment, error) {
 					Containers: []v1.Container{
 						{
 							Name:    "firmament-scheduler",
-							Image:   "huaweifirmament/firmament:gang_scheduling",
+							Image:   "huaweifirmament/firmament:with_ephemeral_fix",
 							Command: []string{"/firmament/build/src/firmament_scheduler", "--flagfile=/firmament/config/firmament_scheduler_cpu_mem.cfg"},
 							Ports:   []v1.ContainerPort{{ContainerPort: 9090}},
 						},


### PR DESCRIPTION
This PR address an issue with the failing ephemeral test case under the 'sig-scheduling'.
Prior to this fix Poseidon was converting the Memory and ephemeral units to Kilobytes and this was causing a corner case to fail, since due to conversion we were losing some bytes from the memory and ephemeral calculation. Now this issue is addressed by this fix.