### PR TITLE
Adding E2E test case for max-pods

### DIFF
--- a/pkg/k8sclient/events.go
+++ b/pkg/k8sclient/events.go
@@ -115,7 +115,7 @@ func (posiedonEvents *PoseidonEvents) ProcessFailureEvents(unscheduledTasks []ui
 			if poseidonToK8sPod, ok := PodToK8sPod[podIdentifier]; ok {
 				ProcessedPodEvents[podIdentifier] = poseidonToK8sPod
 				// send the failure event and update the pods status
-				posiedonEvents.podEvents.Recorder.Eventf(poseidonToK8sPod, corev1.EventTypeWarning, "FailedScheduling", "Firmament failed to schedule the pod %s in %s namespace", podIdentifier.Namespace, podIdentifier.Name)
+				posiedonEvents.podEvents.Recorder.Eventf(poseidonToK8sPod, corev1.EventTypeWarning, "FailedScheduling", "Firmament failed to schedule the pod %s in %s namespace", podIdentifier.Name, podIdentifier.Namespace)
 				Update(posiedonEvents.k8sClient, poseidonToK8sPod, &corev1.PodCondition{
 					Type:    corev1.PodScheduled,
 					Status:  corev1.ConditionFalse,


### PR DESCRIPTION
Adding an e2e test for max-pods feature.
This test case is taken from the sig-scheduling max-pods e2e test case.
This is to test if the Max-Pods flag per node works as advertised.